### PR TITLE
Changed ADC fifo_generator name

### DIFF
--- a/ip/Zmods/ZmodADC1410Controller/component.xml
+++ b/ip/Zmods/ZmodADC1410Controller/component.xml
@@ -1348,7 +1348,7 @@
     <spirit:fileSet>
       <spirit:name>xilinx_anylanguagesynthesis_view_fileset</spirit:name>
       <spirit:file>
-        <spirit:name>src/fifo_generator_0/fifo_generator_0.xci</spirit:name>
+        <spirit:name>src/fifo_generator_adc/fifo_generator_adc.xci</spirit:name>
         <spirit:userFileType>xci</spirit:userFileType>
       </spirit:file>
       <spirit:file>
@@ -1374,7 +1374,7 @@
     <spirit:fileSet>
       <spirit:name>xilinx_anylanguagebehavioralsimulation_view_fileset</spirit:name>
       <spirit:file>
-        <spirit:name>src/fifo_generator_0/fifo_generator_0.xci</spirit:name>
+        <spirit:name>src/fifo_generator_adc/fifo_generator_adc.xci</spirit:name>
         <spirit:userFileType>xci</spirit:userFileType>
       </spirit:file>
       <spirit:file>

--- a/ip/Zmods/ZmodADC1410Controller/src/ZmodADC1410_Controller.vhd
+++ b/ip/Zmods/ZmodADC1410Controller/src/ZmodADC1410_Controller.vhd
@@ -154,7 +154,7 @@ Port (
         sDone : out STD_LOGIC);
 end component;
 
-COMPONENT fifo_generator_0
+COMPONENT fifo_generator_adc
   PORT (
     rst : IN STD_LOGIC;
     wr_clk : IN STD_LOGIC;
@@ -1086,7 +1086,7 @@ end process;
 
 -- Data Path FIFOs
 
-InstChAFIFO : fifo_generator_0 --CHA FIFO
+InstChAFIFO : fifo_generator_adc --CHA FIFO
   PORT MAP (
     rst => sInitDoneR_n,
     wr_clk => DcoBufgClk,
@@ -1101,7 +1101,7 @@ InstChAFIFO : fifo_generator_0 --CHA FIFO
     almost_empty => sFIFO_AlmostEmptyChA
   );
 
-InstChBFIFO : fifo_generator_0  --CHB FIFO
+InstChBFIFO : fifo_generator_adc  --CHB FIFO
   PORT MAP (
     rst => sInitDoneR_n,
     wr_clk => DcoBufgClk,

--- a/ip/Zmods/ZmodADC1410Controller/src/fifo_generator_adc/fifo_generator_adc.xci
+++ b/ip/Zmods/ZmodADC1410Controller/src/fifo_generator_adc/fifo_generator_adc.xci
@@ -6,7 +6,7 @@
   <spirit:version>1.0</spirit:version>
   <spirit:componentInstances>
     <spirit:componentInstance>
-      <spirit:instanceName>fifo_generator_0</spirit:instanceName>
+      <spirit:instanceName>fifo_generator_adc</spirit:instanceName>
       <spirit:componentRef spirit:vendor="xilinx.com" spirit:library="ip" spirit:name="fifo_generator" spirit:version="13.2"/>
       <spirit:configurableElementValues>
         <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.CORE_CLK.ASSOCIATED_BUSIF"/>
@@ -327,7 +327,7 @@
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.C_SELECT_XPM">0</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Clock_Enable_Type">Slave_Interface_Clock_Enable</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Clock_Type_AXI">Common_Clock</spirit:configurableElementValue>
-        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Component_Name">fifo_generator_0</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Component_Name">fifo_generator_adc</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.DATA_WIDTH">64</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Data_Count">false</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Data_Count_Width">5</spirit:configurableElementValue>


### PR DESCRIPTION
Changed fifo_generator name to something more unique. This was causing problems when running global synthesis alongside the DPTI core.