### PR TITLE
PmodOLEDrgb_v1_0: update cSource and cHeader paths

### DIFF
--- a/ip/Pmods/pmodOLEDrgb_v1_0/component.xml
+++ b/ip/Pmods/pmodOLEDrgb_v1_0/component.xml
@@ -2001,31 +2001,31 @@
         <spirit:fileType>cSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
-        <spirit:name>drivers/pmodOLEDrgb_v1_0/src/xspi.c</spirit:name>
+        <spirit:name>drivers/PmodOLEDrgb_v1_0/src/xspi.c</spirit:name>
         <spirit:fileType>cSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
-        <spirit:name>drivers/pmodOLEDrgb_v1_0/src/xspi.h</spirit:name>
+        <spirit:name>drivers/PmodOLEDrgb_v1_0/src/xspi.h</spirit:name>
         <spirit:userFileType>cHeader</spirit:userFileType>
       </spirit:file>
       <spirit:file>
-        <spirit:name>drivers/pmodOLEDrgb_v1_0/src/xspi_i.h</spirit:name>
+        <spirit:name>drivers/PmodOLEDrgb_v1_0/src/xspi_i.h</spirit:name>
         <spirit:userFileType>cHeader</spirit:userFileType>
       </spirit:file>
       <spirit:file>
-        <spirit:name>drivers/pmodOLEDrgb_v1_0/src/xspi_l.h</spirit:name>
+        <spirit:name>drivers/PmodOLEDrgb_v1_0/src/xspi_l.h</spirit:name>
         <spirit:userFileType>cHeader</spirit:userFileType>
       </spirit:file>
       <spirit:file>
-        <spirit:name>drivers/pmodOLEDrgb_v1_0/src/xspi_options.c</spirit:name>
+        <spirit:name>drivers/PmodOLEDrgb_v1_0/src/xspi_options.c</spirit:name>
         <spirit:fileType>cSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
-        <spirit:name>drivers/pmodOLEDrgb_v1_0/src/xspi_selftest.c</spirit:name>
+        <spirit:name>drivers/PmodOLEDrgb_v1_0/src/xspi_selftest.c</spirit:name>
         <spirit:fileType>cSource</spirit:fileType>
       </spirit:file>
       <spirit:file>
-        <spirit:name>drivers/pmodOLEDrgb_v1_0/src/xspi_stats.c</spirit:name>
+        <spirit:name>drivers/PmodOLEDrgb_v1_0/src/xspi_stats.c</spirit:name>
         <spirit:fileType>cSource</spirit:fileType>
       </spirit:file>
     </spirit:fileSet>


### PR DESCRIPTION
The update to 2019.1 broke some of the path variables for the OLED RGB
PMOD. Specifically, it replaced the path with a case-insensitive folder
name, likely missed as this would not be a problem in NTFS file systems.

When using the PMOD in a case-sensitive file system, several source
files and headers are missing after exporting the hardware and launching
the SDK. All of the files which have incorrect paths are related to SPI
library files. This causes any includes to error as well as some rather
strange and silent errors.

Fixing the path name resolves these issues.

This patch fixes a regression from:
commit 097565b44cb00a5161bf3dd5684d25c0fc18628e

Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>