### PR TITLE
Fix warning Synth 8-614

### DIFF
--- a/ip/rgb2dvi/src/ClockGen.vhd
+++ b/ip/rgb2dvi/src/ClockGen.vhd
@@ -94,7 +94,7 @@ PLL_LockSyncAsync: SyncAsync
       OutClk => PixelClkIn,
       oOut => pLocked);
       
-PLL_LockLostDetect: process(PixelClkIn)
+PLL_LockLostDetect: process(PixelClkIn, pRst)
 begin
    if (pRst = '1') then
       pLocked_q <= (others => '0');


### PR DESCRIPTION
`WARNING: [Synth 8-614] signal 'pRst' is read in the process but is not in the sensitivity list [.../src/ClockGen.vhd:97]`