### PR TITLE
Repackaged Zmod Scope IP After Previous XIT Comment Updates

### DIFF
--- a/ip/Zmods/ZmodScopeController/component.xml
+++ b/ip/Zmods/ZmodScopeController/component.xml
@@ -355,7 +355,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>fc6b9a00</spirit:value>
+            <spirit:value>cb100b37</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -374,7 +374,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>bfa0498a</spirit:value>
+            <spirit:value>9f30ce12</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -402,7 +402,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>a775bd65</spirit:value>
+            <spirit:value>eeda2e4a</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -430,7 +430,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>30cb15f3</spirit:value>
+            <spirit:value>735fddbc</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -1496,6 +1496,7 @@
       <spirit:file>
         <spirit:name>src/ZmodADC_SynchonizationFIFO.xci</spirit:name>
         <spirit:userFileType>xci</spirit:userFileType>
+        <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
         <spirit:userFileType>CELL_NAME_InstDataPath/InstADC_FIFO</spirit:userFileType>
       </spirit:file>
       <spirit:file>
@@ -1570,6 +1571,7 @@
       <spirit:file>
         <spirit:name>src/ZmodADC_SynchonizationFIFO.xci</spirit:name>
         <spirit:userFileType>xci</spirit:userFileType>
+        <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
         <spirit:userFileType>CELL_NAME_InstDataPath/InstADC_FIFO</spirit:userFileType>
       </spirit:file>
       <spirit:file>
@@ -1828,7 +1830,7 @@
         <xilinx:xpmLibrary>XPM_CDC</xilinx:xpmLibrary>
         <xilinx:xpmLibrary>XPM_MEMORY</xilinx:xpmLibrary>
       </xilinx:xpmLibraries>
-      <xilinx:coreRevision>1</xilinx:coreRevision>
+      <xilinx:coreRevision>2</xilinx:coreRevision>
       <xilinx:upgrades>
         <xilinx:canUpgradeFrom>natinst.com:user:ZmodADC1410_Controller:1.0</xilinx:canUpgradeFrom>
         <xilinx:canUpgradeFrom>natinst.com:user:ZmodADC_Controller:1.0</xilinx:canUpgradeFrom>
@@ -1836,7 +1838,7 @@
         <xilinx:canUpgradeFrom>digilent.com:user:ZmodScopeController:1.0</xilinx:canUpgradeFrom>
         <xilinx:canUpgradeFrom>digilent.com:user:ZmodScopeController:1.1</xilinx:canUpgradeFrom>
       </xilinx:upgrades>
-      <xilinx:coreCreationDateTime>2022-11-04T00:25:47Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2023-02-02T18:12:57Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@fe99ea0_ARCHIVE_LOCATION">c:/Vivado_Projects/SimAD9648LLController/CreatedIP</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.dd@7ecb3ff9_ARCHIVE_LOCATION">c:/Vivado_Projects/SimAD9648LLController/CreatedIP</xilinx:tag>
@@ -5247,12 +5249,27 @@
         <xilinx:tag xilinx:name="ui.data.coregen.df@449a63ea_ARCHIVE_LOCATION">d:/Github/Eclypse-Review/ddr-streaming-awg-scope/hw/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.df@20114b69_ARCHIVE_LOCATION">d:/Github/Eclypse-Review/ddr-streaming-awg-scope/hw/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.df@37de82f4_ARCHIVE_LOCATION">d:/Github/Eclypse-Review/ddr-streaming-awg-scope/hw/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@3a135bc5_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@70f95b3e_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@24d98030_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@35766d77_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@6b128d7d_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@66fdba4f_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@5e41f14d_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@6734a5d1_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@112b1b66_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@32dcd6ad_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@32c3ed0d_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@6a3beef5_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@1329fead_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@37c19ea3_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@166f9a90_ARCHIVE_LOCATION">d:/Ionut/ZmodScopeIPUpdate/Eclypse-Z7-HW/repo/vivado-library/ip/Zmods/ZmodScopeController</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2021.1</xilinx:xilinxVersion>
       <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="1522777d"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="0e107b06"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="46a0bf97"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="550f0532"/>
       <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="f287e66d"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="e68367ba"/>

--- a/ip/Zmods/ZmodScopeController/src/generate_timing_xdc.xit
+++ b/ip/Zmods/ZmodScopeController/src/generate_timing_xdc.xit
@@ -99,16 +99,29 @@ puts_ipfile $f_xdc {}
 set data_bus_width [get_property PARAM_VALUE.kADC_Width]
 puts "  data_bus_width: $data_bus_width"
 
-puts_ipfile $f_xdc {# Using the Vivado 2021.1 Language Template for input delay constraints, for a}
-puts_ipfile $f_xdc {# source-synchronous, center-aligned double data rate interface and applying it to the ADC}
-puts_ipfile $f_xdc {# interface, it results that we would need to add $tDCO_half to each constraint value.}
-puts_ipfile $f_xdc {# However, based on post-implementation Vivado timing results, the conclusion was that the}
-puts_ipfile $f_xdc {# clock is "hurried" so much by the MMCM that timing should be analyzed versus the}
-puts_ipfile $f_xdc {# previous data phase, for both setup and hold. Therefore, I removed the “+ $tDCO_half”}
-puts_ipfile $f_xdc {# term from the below constraints.}
-puts_ipfile $f_xdc {# Also, I adjusted the MMCM clock output phase to 120...127.5deg (depending on sampling}
-puts_ipfile $f_xdc {# period) to split the negative slack between setup and hold and to further optimize}
-puts_ipfile $f_xdc {# timing (see DataPath.vhd and PkgZmodADC.vhd for more details).}
+puts_ipfile $f_xdc {# The constraints below were written based on the Vivado 2021.1}
+puts_ipfile $f_xdc {# Language Template for input delay constraints, for a}
+puts_ipfile $f_xdc {# source-synchronous, edge-aligned double data rate interface }
+puts_ipfile $f_xdc {# (Clock with MMCM) and applying it to the ADC interface.}
+puts_ipfile $f_xdc {# Also, I adjusted the MMCM clock output phase to 120...127.5deg}
+puts_ipfile $f_xdc {# (depending on sampling period) to split the negative slack between}
+puts_ipfile $f_xdc {# setup and hold and to further optimize timing (see DataPath.vhd and}
+puts_ipfile $f_xdc {# PkgZmodADC.vhd for more details).}
+puts_ipfile $f_xdc {# ===== IMPORTANT! =====}
+puts_ipfile $f_xdc {# In case migration to Ultrascale+ architecture is necessary, care}
+puts_ipfile $f_xdc {# must be taken since on that architecture, the MMCM}
+puts_ipfile $f_xdc {# "PHASESHIFT_MODE" property is by default set to LATENCY instead of}
+puts_ipfile $f_xdc {# WAVEFORM. This property change modifies the destination clock}
+puts_ipfile $f_xdc {# waveform in the timing analysis i.e. it changes the destination}
+puts_ipfile $f_xdc {# clock edge on which timing analysis is performed. The result is}
+puts_ipfile $f_xdc {# that timing analysis will be performed between incorrect edges,}
+puts_ipfile $f_xdc {# thus failing timing.}
+puts_ipfile $f_xdc {# For Ultrascale+ architecture, the solution would be to change the}
+puts_ipfile $f_xdc {# constraints template to source-synchronous, CENTER-aligned double}
+puts_ipfile $f_xdc {# data rate interface. As a result, the way the constraint values are}
+puts_ipfile $f_xdc {# computed will be different i.e. $tDCO_half will need to be added to}
+puts_ipfile $f_xdc {# all constraint values.}
+puts_ipfile $f_xdc {# ======================}
 for {set index 0} {$index < $data_bus_width} {incr index} {
 	set constr_block {set_input_delay -clock [get_clocks ZmodDcoClk] -clock_fall -min [expr $tskew_min + $net_delay_d<index> - $OutputDelay - $net_delay_dcoclk - $net_skew_ecl] [get_ports {dZmodADC_Data[<index>]} -prop_thru_buffers]
 set_input_delay -clock [get_clocks ZmodDcoClk] -clock_fall -max [expr $tskew_max + $net_delay_d<index> - $OutputDelay - $net_delay_dcoclk + $net_skew_ecl] [get_ports {dZmodADC_Data[<index>]} -prop_thru_buffers]


### PR DESCRIPTION
I had forgot to repackage the Zmod Scope IP after the XIT comment updates I made yesterday.
I have now repackaged it so the checksums in component.xml are up to date. I have also ran a synthesis + implementation to check that the IP is not broken and that it still passes timing.