### PR TITLE
Updated the comments describing the ADC interface timing constraints.…

### DIFF
--- a/ip/Zmods/ZmodDigitizerController/component.xml
+++ b/ip/Zmods/ZmodDigitizerController/component.xml
@@ -335,7 +335,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>f5db5219</spirit:value>
+            <spirit:value>72e556bb</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -379,21 +379,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>428623d2</spirit:value>
-          </spirit:parameter>
-        </spirit:parameters>
-      </spirit:view>
-      <spirit:view>
-        <spirit:name>xilinx_implementation</spirit:name>
-        <spirit:displayName>Implementation</spirit:displayName>
-        <spirit:envIdentifier>:vivado.xilinx.com:implementation</spirit:envIdentifier>
-        <spirit:fileSetRef>
-          <spirit:localName>xilinx_implementation_view_fileset</spirit:localName>
-        </spirit:fileSetRef>
-        <spirit:parameters>
-          <spirit:parameter>
-            <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>45fab15e</spirit:value>
+            <spirit:value>367645c1</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -408,6 +394,20 @@
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
             <spirit:value>d6a6b079</spirit:value>
+          </spirit:parameter>
+        </spirit:parameters>
+      </spirit:view>
+      <spirit:view>
+        <spirit:name>xilinx_implementation</spirit:name>
+        <spirit:displayName>Implementation</spirit:displayName>
+        <spirit:envIdentifier>:vivado.xilinx.com:implementation</spirit:envIdentifier>
+        <spirit:fileSetRef>
+          <spirit:localName>xilinx_implementation_view_fileset</spirit:localName>
+        </spirit:fileSetRef>
+        <spirit:parameters>
+          <spirit:parameter>
+            <spirit:name>viewChecksum</spirit:name>
+            <spirit:value>bb7d32cf</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -1133,6 +1133,10 @@
         <spirit:userFileType>xdc</spirit:userFileType>
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
         <spirit:userFileType>USED_IN_out_of_context</spirit:userFileType>
+        <spirit:define>
+          <spirit:name>processing_order</spirit:name>
+          <spirit:value>early</spirit:value>
+        </spirit:define>
       </spirit:file>
       <spirit:file>
         <spirit:name>src/PkgZmodDigitizer.vhd</spirit:name>
@@ -1294,6 +1298,13 @@
       </spirit:file>
     </spirit:fileSet>
     <spirit:fileSet>
+      <spirit:name>xilinx_productguide_view_fileset</spirit:name>
+      <spirit:file>
+        <spirit:name>docs/ZmodDigitizerController.pdf</spirit:name>
+        <spirit:userFileType>pdf</spirit:userFileType>
+      </spirit:file>
+    </spirit:fileSet>
+    <spirit:fileSet>
       <spirit:name>xilinx_implementation_view_fileset</spirit:name>
       <spirit:file>
         <spirit:name>src/generate_timing_xdc.xit</spirit:name>
@@ -1310,13 +1321,6 @@
           <spirit:name>processing_order</spirit:name>
           <spirit:value>early</spirit:value>
         </spirit:define>
-      </spirit:file>
-    </spirit:fileSet>
-    <spirit:fileSet>
-      <spirit:name>xilinx_productguide_view_fileset</spirit:name>
-      <spirit:file>
-        <spirit:name>docs/ZmodDigitizerController.pdf</spirit:name>
-        <spirit:userFileType>pdf</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
   </spirit:fileSets>
@@ -1455,11 +1459,11 @@
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
       <xilinx:vendorDisplayName>Digilent</xilinx:vendorDisplayName>
       <xilinx:vendorURL>https://www.digilent.com</xilinx:vendorURL>
-      <xilinx:coreRevision>2</xilinx:coreRevision>
+      <xilinx:coreRevision>3</xilinx:coreRevision>
       <xilinx:upgrades>
         <xilinx:canUpgradeFrom>xilinx.com:user:ZmodDigitizerController:1.0</xilinx:canUpgradeFrom>
       </xilinx:upgrades>
-      <xilinx:coreCreationDateTime>2022-11-12T00:49:28Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2023-03-08T13:25:18Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
         <xilinx:tag xilinx:name="ui.data.coregen.df@7b2ddaf7_ARCHIVE_LOCATION">d:/Digilent/ZmodDigitizer</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.df@39d996ea_ARCHIVE_LOCATION">d:/Digilent/ZmodDigitizer</xilinx:tag>
@@ -5439,12 +5443,34 @@
         <xilinx:tag xilinx:name="ui.data.coregen.df@3f38b59e_ARCHIVE_LOCATION">d:/Github/Eclypse-Review/ddr-streaming-awg-digitizer/hw/repo/vivado-library/ip/Zmods/ZmodDigitizerController</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.df@4c612941_ARCHIVE_LOCATION">d:/Github/Eclypse-Review/ddr-streaming-awg-digitizer/hw/repo/vivado-library/ip/Zmods/ZmodDigitizerController</xilinx:tag>
         <xilinx:tag xilinx:name="ui.data.coregen.df@6fc02403_ARCHIVE_LOCATION">d:/Github/Eclypse-Review/ddr-streaming-awg-digitizer/hw/repo/vivado-library/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@79004e16_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@155c8104_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@79db3b13_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@6e15b368_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@2202d006_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@350f5cb2_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@367e628e_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@2d5e2356_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@12ebd208_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@1dfdae35_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@57a52a5f_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@67419438_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@11d2d0f9_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@502d7a3b_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@2dbf6386_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@70248a76_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@73bf6e6a_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@73a5f345_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@6b18e067_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@3ee0fd33_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@63da54a1_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.df@f92ba42_ARCHIVE_LOCATION">g:/viv-lib/ip/Zmods/ZmodDigitizerController</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2021.1</xilinx:xilinxVersion>
       <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="b2b6f517"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="de29435c"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="cfd810da"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="40408c1d"/>
       <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="906686da"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="df9264d9"/>

--- a/ip/Zmods/ZmodDigitizerController/src/ConstrZmodDigitizer_ooc.xdc
+++ b/ip/Zmods/ZmodDigitizerController/src/ConstrZmodDigitizer_ooc.xdc
@@ -1,2 +1,4 @@
 set ClockGenPriRefClk_period 2.500; # 400MHz max frequency expected for ClockGenPriRefClk_period
 create_clock -period $ClockGenPriRefClk_period -name ClockGenPriRefClk -waveform {0.000 1.250} -add [get_ports ClockGenPriRefClk]
+set SysClk100_period 10.000; # 100MHz frequency expected for SysClk100
+create_clock -period $SysClk100_period -name SysClk100 -waveform {0.000 5.000} -add [get_ports SysClk100]

--- a/ip/Zmods/ZmodDigitizerController/src/generate_clocks.xit
+++ b/ip/Zmods/ZmodDigitizerController/src/generate_clocks.xit
@@ -6,10 +6,9 @@ puts_ipfile $f_xdc {# DCO Clock period}
 puts_ipfile $f_xdc {set tDCO [get_property CLKIN1_PERIOD [get_cells InstDataPath/Digitizer_MMCM]];}
 puts_ipfile $f_xdc {set tDCO_half [expr $tDCO/2];}
 puts_ipfile $f_xdc {create_clock -period $tDCO -name DcoClkIn -waveform "0.000 $tDCO_half" [get_ports DcoClkIn -prop_thru_buffers]}
-puts_ipfile $f_xdc {set_clock_groups -asynchronous -group DcoClkIn -group [get_clocks -of_objects [get_ports SysClk100]]}
-puts_ipfile $f_xdc {}
-
 puts_ipfile $f_xdc {create_generated_clock -name CG_InputClk -source [get_pins InstCG_ClkODDR/C] -add -master_clock [get_clocks -of [get_ports ClockGenPriRefClk]] -divide_by 1 [get_ports CG_InputClk_p]}
+puts_ipfile $f_xdc {}
+puts_ipfile $f_xdc {set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks {DcoClkIn}] -group [get_clocks -include_generated_clocks {SysClk100 ClockGenPriRefClk CG_InputClk}]}
 puts_ipfile $f_xdc {}
 
 close_ipfile $f_xdc

--- a/ip/Zmods/ZmodDigitizerController/src/generate_timing_xdc.xit
+++ b/ip/Zmods/ZmodDigitizerController/src/generate_timing_xdc.xit
@@ -96,17 +96,34 @@ puts_ipfile $f_xdc {# Maximum net skew on Eclypse Z7 is 1mm; @ 140mm / 1ns this 
 puts_ipfile $f_xdc {set net_skew_ecl 0.007}
 puts_ipfile $f_xdc {}
 
-puts_ipfile $f_xdc {# Using the Vivado 2021.1 Language Template for input delay constraints, for a}
-puts_ipfile $f_xdc {# source-synchronous, center-aligned double data rate interface and applying it to the ADC}
-puts_ipfile $f_xdc {# interface, it results that we would need to add $tDCO_half to each constraint value.}
-puts_ipfile $f_xdc {# However, based on post-implementation Vivado timing results, the conclusion was that the}
-puts_ipfile $f_xdc {# clock is "hurried" so much by the MMCM that timing should be analyzed versus the}
-puts_ipfile $f_xdc {# previous data phase, for both setup and hold. Therefore, I removed the â€œ+ $tDCO_halfâ€?}
-puts_ipfile $f_xdc {# term from the below constraints.}
-puts_ipfile $f_xdc {# Also, I adjusted the MMCM clock output phase to 120...127.5deg (depending on sampling}
-puts_ipfile $f_xdc {# period) to split the negative slack between setup and hold and to further optimize}
-puts_ipfile $f_xdc {# timing (see DataPath.vhd and PkgZmodDigitizer.vhd for more details).}
-for {set index 0} {$index < 14} {incr index} {
+# Only generate constraints for 
+set data_bus_width [get_property PARAM_VALUE.kADC_Width]
+puts "  data_bus_width: $data_bus_width"
+
+puts_ipfile $f_xdc {# The constraints below were written based on the Vivado 2021.1}
+puts_ipfile $f_xdc {# Language Template for input delay constraints, for a}
+puts_ipfile $f_xdc {# source-synchronous, edge-aligned double data rate interface }
+puts_ipfile $f_xdc {# (Clock with MMCM) and applying it to the ADC interface.}
+puts_ipfile $f_xdc {# Also, the MMCM clock output phase was adjusted to 120...127.5deg}
+puts_ipfile $f_xdc {# (depending on sampling period) to split the negative slack between}
+puts_ipfile $f_xdc {# setup and hold and to further optimize timing (see DataPath.vhd and}
+puts_ipfile $f_xdc {# PkgZmodADC.vhd for more details).}
+puts_ipfile $f_xdc {# ===== IMPORTANT! =====}
+puts_ipfile $f_xdc {# In case of migration to the Ultrascale+ architecture is necessary, care}
+puts_ipfile $f_xdc {# must be taken since on that architecture, the MMCM}
+puts_ipfile $f_xdc {# "PHASESHIFT_MODE" property is by default set to LATENCY instead of}
+puts_ipfile $f_xdc {# WAVEFORM. This property change modifies the destination clock}
+puts_ipfile $f_xdc {# waveform in the timing analysis i.e. it changes the destination}
+puts_ipfile $f_xdc {# clock edge on which timing analysis is performed. The result is}
+puts_ipfile $f_xdc {# that timing analysis will be performed between incorrect edges,}
+puts_ipfile $f_xdc {# thus failing timing.}
+puts_ipfile $f_xdc {# For the Ultrascale+ architecture, the solution would be to change the}
+puts_ipfile $f_xdc {# constraints template to source-synchronous, CENTER-aligned double}
+puts_ipfile $f_xdc {# data rate interface. As a result, the way the constraint values are}
+puts_ipfile $f_xdc {# computed will be different i.e. $tDCO_half will need to be added to}
+puts_ipfile $f_xdc {# all constraint values.}
+puts_ipfile $f_xdc {# ======================}
+for {set index 0} {$index < $data_bus_width} {incr index} {
 	set constr_block {set_input_delay -clock [get_clocks DcoClkIn] -clock_fall -min [expr $tskew_min + $net_delay_d<index> - $OutputDelay - $net_delay_dcoclk - $net_skew_ecl] [get_ports {diZmodADC_Data[<index>]} -prop_thru_buffers]
 set_input_delay -clock [get_clocks DcoClkIn] -clock_fall -max [expr $tskew_max + $net_delay_d<index> - $OutputDelay - $net_delay_dcoclk + $net_skew_ecl] [get_ports {diZmodADC_Data[<index>]} -prop_thru_buffers]
 set_input_delay -clock [get_clocks DcoClkIn] -min -add_delay [expr $tskew_min + $net_delay_d<index> - $OutputDelay - $net_delay_dcoclk - $net_skew_ecl] [get_ports {diZmodADC_Data[<index>]} -prop_thru_buffers]


### PR DESCRIPTION
… Added a note regarding migration to Ultrascale+. Fixed critical warnings thrown by "set_clock_groups" not being able to set clock group with only one non-empty group remaining.