### PR TITLE
Updated constraint comments for triple synchronizers.

### DIFF
--- a/module/synchronizers/HandshakeData.vhd
+++ b/module/synchronizers/HandshakeData.vhd
@@ -63,21 +63,21 @@
 --      input clock domain and output clock domain needs to not be analized:
 --      set_false_path -through [get_pins -filter {NAME =~ *SyncAsync*/oSyncStages_reg[0]/D} -hier]
 --
---    - Also for the SyncAsync modules, the path between the flip-flops in
+--    - Also for the SyncAsync modules, the path(s) between the flip-flops in
 --      the output clock domain needs to be overconstrained to half of the
 --      output clock period, to leave the other half for metastability to
 --      settle:
 --      set ClkPeriod [get_property PERIOD [get_clocks -of_objects [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushTBack*/oSyncStages_reg[0]/C} -hier]]]
---      set_max_delay -from [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushTBack*/oSyncStages_reg[0]/C} -hier] -to [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushTBack*/oSyncStages_reg[1]/D} -hier] [expr {$ClkPeriod/2}]
+--      set_max_delay -from [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushTBack*/oSyncStages_reg[*]/C} -hier] -to [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushTBack*/oSyncStages_reg[*]/D} -hier] [expr {$ClkPeriod/2}]
 --      set ClkPeriod [get_property PERIOD [get_clocks -of_objects [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushT/oSyncStages_reg[0]/C} -hier]]]
---      set_max_delay -from [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushT/oSyncStages_reg[0]/C} -hier] -to [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushT/oSyncStages_reg[1]/D} -hier] [expr {$ClkPeriod/2}]
+--      set_max_delay -from [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushT/oSyncStages_reg[*]/C} -hier] -to [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncAsyncPushT/oSyncStages_reg[*]/D} -hier] [expr {$ClkPeriod/2}]
 --
---    - For the ResetBridge module inside this module, the path between the
+--    - For the ResetBridge module inside this module, the path(s) between the
 --      flip-flops in the output clock domain needs to be overconstrained to
 --      half of the output clock period, to leave the other half for
 --      metastability to settle:
 --      set ClkPeriod [get_property PERIOD [get_clocks -of_objects [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncReset*SyncAsync*/oSyncStages_reg[0]/C} -hier]]]
---      set_max_delay -from [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncReset*SyncAsync*/oSyncStages_reg[0]/C} -hier] -to [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncReset*SyncAsync*/oSyncStages_reg[1]/D} -hier] [expr {$ClkPeriod/2}]
+--      set_max_delay -from [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncReset*SyncAsync*/oSyncStages_reg[*]/C} -hier] -to [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*SyncReset*SyncAsync*/oSyncStages_reg[*]/D} -hier] [expr {$ClkPeriod/2}]
 --
 --    - Also for the ResetBridge module, we need to disable timing analysis on
 --      the reset paths, for both its edges. This is necessary because the
@@ -88,6 +88,9 @@
 --      domain, the maximum delay needs to be set to 2 output clock cycles, so
 --      the data sampled in the output clock domain is stable by the time
 --      oPushTChanged is asserted.
+--      If the double synchronizers inside the HandshakeData module are changed to triple
+--      synchronizers (e.g. for Ultrascale architecture), then the value of this
+--      constraint needs to be set to 3 output clock cycles.
 --      set ClkPeriod [get_property PERIOD [get_clocks -of_objects [get_pins -filter {NAME =~ *<HandshakeData instantiation name>*/oData_reg[0]/C} -hier]]]
 --      set_max_delay -datapath_only -from [get_cells -hier -filter {NAME =~ *<HandshakeData instantiation name>*/iData_int_reg[*]}] -to [get_cells -hier -filter {NAME=~ *<HandshakeData instantiation name>*/oData_reg[*]}] [expr {$ClkPeriod*2}]
 
@@ -100,6 +103,8 @@
 --    oPushTChanged, to make sure both the InClk and OutClk data latching FFs
 --    use actual clock enable (CE) pins.
 --    2022-Oct-04: Added Constraint Templates section to the header comments.
+--    2023-Oct-17: Updated Constraint Templates section for triple
+--    synchronizers.
 -------------------------------------------------------------------------------
 
 

--- a/module/synchronizers/SyncBase.vhd
+++ b/module/synchronizers/SyncBase.vhd
@@ -48,7 +48,7 @@
 -- asserted independently.
 --
 -- Constraints:
--- # Replace <InstSyncBase> with path to SyncAsync instance, keep rest unchanged
+-- # Replace <InstSyncBase> with path to SyncBase instance, keep rest unchanged
 -- # Begin scope to SyncBase instance
 -- current_instance [get_cells <InstSyncBase>]
 -- # Input to synchronizer ignored for timing analysis


### PR DESCRIPTION
I updated the HandshakeData constraint comments and template to also consider the case when triple synchronizers are used (e.g. for Ultrascale architecture). I corrected an error in the SyncBase constraint comments.