### PR TITLE
Update all SyncAsync that have aReset as an input to be the same

### DIFF
--- a/ip/AXI_DPTI_1.0/src/SyncAsync.vhd
+++ b/ip/AXI_DPTI_1.0/src/SyncAsync.vhd
@@ -3,37 +3,30 @@
 -- File: SyncAsync.vhd
 -- Author: Elod Gyorgy
 -- Original Project: HDMI input on 7-series Xilinx FPGA
--- Date: 20 October 2014
+-- Date: 15 December 2017
 --
 -------------------------------------------------------------------------------
--- (c) 2014 Copyright Digilent Incorporated
--- All Rights Reserved
--- 
--- This program is free software; distributed under the terms of BSD 3-clause 
--- license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+--MIT License
 --
--- Redistribution and use in source and binary forms, with or without modification,
--- are permitted provided that the following conditions are met:
+--Copyright (c) 2016 Digilent
 --
--- 1. Redistributions of source code must retain the above copyright notice, this
---    list of conditions and the following disclaimer.
--- 2. Redistributions in binary form must reproduce the above copyright notice,
---    this list of conditions and the following disclaimer in the documentation
---    and/or other materials provided with the distribution.
--- 3. Neither the name(s) of the above-listed copyright holder(s) nor the names
---    of its contributors may be used to endorse or promote products derived
---    from this software without specific prior written permission.
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
 --
--- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
--- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
--- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
--- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
--- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
--- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
--- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
--- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
--- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
 --
 -------------------------------------------------------------------------------
 --
@@ -61,9 +54,10 @@ use IEEE.STD_LOGIC_1164.ALL;
 entity SyncAsync is
    Generic (
       kResetTo : std_logic := '0'; --value when reset and upon init
-      kStages : natural := 2); --double sync by default
+      kStages : natural := 2; --double sync by default
+      kResetPolarity : std_logic := '1'); --aReset active-high by default
    Port (
-      aReset : in STD_LOGIC; -- active-high asynchronous reset
+      aReset : in STD_LOGIC; -- active-high/active-low asynchronous reset
       aIn : in STD_LOGIC;
       OutClk : in STD_LOGIC;
       oOut : out STD_LOGIC);
@@ -77,7 +71,7 @@ begin
 
 Sync: process (OutClk, aReset)
 begin
-   if (aReset = '1') then
+   if (aReset = kResetPolarity) then
       oSyncStages <= (others => kResetTo);
    elsif Rising_Edge(OutClk) then
       oSyncStages <= oSyncStages(oSyncStages'high-1 downto 0) & aIn;

--- a/ip/Sync_v1_0/src/SyncAsync.vhd
+++ b/ip/Sync_v1_0/src/SyncAsync.vhd
@@ -3,37 +3,30 @@
 -- File: SyncAsync.vhd
 -- Author: Elod Gyorgy
 -- Original Project: HDMI input on 7-series Xilinx FPGA
--- Date: 20 October 2014
+-- Date: 15 December 2017
 --
 -------------------------------------------------------------------------------
--- (c) 2014 Copyright Digilent Incorporated
--- All Rights Reserved
--- 
--- This program is free software; distributed under the terms of BSD 3-clause 
--- license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+--MIT License
 --
--- Redistribution and use in source and binary forms, with or without modification,
--- are permitted provided that the following conditions are met:
+--Copyright (c) 2016 Digilent
 --
--- 1. Redistributions of source code must retain the above copyright notice, this
---    list of conditions and the following disclaimer.
--- 2. Redistributions in binary form must reproduce the above copyright notice,
---    this list of conditions and the following disclaimer in the documentation
---    and/or other materials provided with the distribution.
--- 3. Neither the name(s) of the above-listed copyright holder(s) nor the names
---    of its contributors may be used to endorse or promote products derived
---    from this software without specific prior written permission.
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
 --
--- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
--- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
--- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
--- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
--- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
--- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
--- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
--- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
--- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
 --
 -------------------------------------------------------------------------------
 --
@@ -61,9 +54,10 @@ use IEEE.STD_LOGIC_1164.ALL;
 entity SyncAsync is
    Generic (
       kResetTo : std_logic := '0'; --value when reset and upon init
-      kStages : natural := 2); --double sync by default
+      kStages : natural := 2; --double sync by default
+      kResetPolarity : std_logic := '1'); --aReset active-high by default
    Port (
-      aReset : in STD_LOGIC; -- active-high asynchronous reset
+      aReset : in STD_LOGIC; -- active-high/active-low asynchronous reset
       aIn : in STD_LOGIC;
       OutClk : in STD_LOGIC;
       oOut : out STD_LOGIC);
@@ -77,7 +71,7 @@ begin
 
 Sync: process (OutClk, aReset)
 begin
-   if (aReset = '1') then
+   if (aReset = kResetPolarity) then
       oSyncStages <= (others => kResetTo);
    elsif Rising_Edge(OutClk) then
       oSyncStages <= oSyncStages(oSyncStages'high-1 downto 0) & aIn;

--- a/ip/axi_dynclk/src/SyncAsync.vhd
+++ b/ip/axi_dynclk/src/SyncAsync.vhd
@@ -6,34 +6,27 @@
 -- Date: 15 December 2017
 --
 -------------------------------------------------------------------------------
--- (c) 2014 Copyright Digilent Incorporated
--- All Rights Reserved
--- 
--- This program is free software; distributed under the terms of BSD 3-clause 
--- license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+--MIT License
 --
--- Redistribution and use in source and binary forms, with or without modification,
--- are permitted provided that the following conditions are met:
+--Copyright (c) 2016 Digilent
 --
--- 1. Redistributions of source code must retain the above copyright notice, this
---    list of conditions and the following disclaimer.
--- 2. Redistributions in binary form must reproduce the above copyright notice,
---    this list of conditions and the following disclaimer in the documentation
---    and/or other materials provided with the distribution.
--- 3. Neither the name(s) of the above-listed copyright holder(s) nor the names
---    of its contributors may be used to endorse or promote products derived
---    from this software without specific prior written permission.
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
 --
--- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
--- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
--- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
--- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
--- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
--- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
--- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
--- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
--- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
 --
 -------------------------------------------------------------------------------
 --

--- a/ip/axi_ps2_1.0/src/SyncAsync.vhd
+++ b/ip/axi_ps2_1.0/src/SyncAsync.vhd
@@ -3,37 +3,30 @@
 -- File: SyncAsync.vhd
 -- Author: Elod Gyorgy
 -- Original Project: HDMI input on 7-series Xilinx FPGA
--- Date: 20 October 2014
+-- Date: 15 December 2017
 --
 -------------------------------------------------------------------------------
--- (c) 2014 Copyright Digilent Incorporated
--- All Rights Reserved
--- 
--- This program is free software; distributed under the terms of BSD 3-clause 
--- license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+--MIT License
 --
--- Redistribution and use in source and binary forms, with or without modification,
--- are permitted provided that the following conditions are met:
+--Copyright (c) 2016 Digilent
 --
--- 1. Redistributions of source code must retain the above copyright notice, this
---    list of conditions and the following disclaimer.
--- 2. Redistributions in binary form must reproduce the above copyright notice,
---    this list of conditions and the following disclaimer in the documentation
---    and/or other materials provided with the distribution.
--- 3. Neither the name(s) of the above-listed copyright holder(s) nor the names
---    of its contributors may be used to endorse or promote products derived
---    from this software without specific prior written permission.
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
 --
--- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
--- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
--- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
--- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
--- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
--- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
--- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
--- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
--- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
 --
 -------------------------------------------------------------------------------
 --
@@ -61,9 +54,10 @@ use IEEE.STD_LOGIC_1164.ALL;
 entity SyncAsync is
    Generic (
       kResetTo : std_logic := '0'; --value when reset and upon init
-      kStages : natural := 2); --double sync by default
+      kStages : natural := 2; --double sync by default
+      kResetPolarity : std_logic := '1'); --aReset active-high by default
    Port (
-      aReset : in STD_LOGIC; -- active-high asynchronous reset
+      aReset : in STD_LOGIC; -- active-high/active-low asynchronous reset
       aIn : in STD_LOGIC;
       OutClk : in STD_LOGIC;
       oOut : out STD_LOGIC);
@@ -77,7 +71,7 @@ begin
 
 Sync: process (OutClk, aReset)
 begin
-   if (aReset = '1') then
+   if (aReset = kResetPolarity) then
       oSyncStages <= (others => kResetTo);
    elsif Rising_Edge(OutClk) then
       oSyncStages <= oSyncStages(oSyncStages'high-1 downto 0) & aIn;

--- a/ip/dvi2rgb/src/SyncAsync.vhd
+++ b/ip/dvi2rgb/src/SyncAsync.vhd
@@ -3,37 +3,30 @@
 -- File: SyncAsync.vhd
 -- Author: Elod Gyorgy
 -- Original Project: HDMI input on 7-series Xilinx FPGA
--- Date: 20 October 2014
+-- Date: 15 December 2017
 --
 -------------------------------------------------------------------------------
--- (c) 2014 Copyright Digilent Incorporated
--- All Rights Reserved
--- 
--- This program is free software; distributed under the terms of BSD 3-clause 
--- license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+--MIT License
 --
--- Redistribution and use in source and binary forms, with or without modification,
--- are permitted provided that the following conditions are met:
+--Copyright (c) 2016 Digilent
 --
--- 1. Redistributions of source code must retain the above copyright notice, this
---    list of conditions and the following disclaimer.
--- 2. Redistributions in binary form must reproduce the above copyright notice,
---    this list of conditions and the following disclaimer in the documentation
---    and/or other materials provided with the distribution.
--- 3. Neither the name(s) of the above-listed copyright holder(s) nor the names
---    of its contributors may be used to endorse or promote products derived
---    from this software without specific prior written permission.
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
 --
--- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
--- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
--- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
--- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
--- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
--- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
--- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
--- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
--- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
 --
 -------------------------------------------------------------------------------
 --
@@ -61,9 +54,10 @@ use IEEE.STD_LOGIC_1164.ALL;
 entity SyncAsync is
    Generic (
       kResetTo : std_logic := '0'; --value when reset and upon init
-      kStages : natural := 2); --double sync by default
+      kStages : natural := 2; --double sync by default
+      kResetPolarity : std_logic := '1'); --aReset active-high by default
    Port (
-      aReset : in STD_LOGIC; -- active-high asynchronous reset
+      aReset : in STD_LOGIC; -- active-high/active-low asynchronous reset
       aIn : in STD_LOGIC;
       OutClk : in STD_LOGIC;
       oOut : out STD_LOGIC);
@@ -77,7 +71,7 @@ begin
 
 Sync: process (OutClk, aReset)
 begin
-   if (aReset = '1') then
+   if (aReset = kResetPolarity) then
       oSyncStages <= (others => kResetTo);
    elsif Rising_Edge(OutClk) then
       oSyncStages <= oSyncStages(oSyncStages'high-1 downto 0) & aIn;

--- a/ip/rgb2dvi/src/SyncAsync.vhd
+++ b/ip/rgb2dvi/src/SyncAsync.vhd
@@ -3,37 +3,30 @@
 -- File: SyncAsync.vhd
 -- Author: Elod Gyorgy
 -- Original Project: HDMI input on 7-series Xilinx FPGA
--- Date: 20 October 2014
+-- Date: 15 December 2017
 --
 -------------------------------------------------------------------------------
--- (c) 2014 Copyright Digilent Incorporated
--- All Rights Reserved
--- 
--- This program is free software; distributed under the terms of BSD 3-clause 
--- license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+--MIT License
 --
--- Redistribution and use in source and binary forms, with or without modification,
--- are permitted provided that the following conditions are met:
+--Copyright (c) 2016 Digilent
 --
--- 1. Redistributions of source code must retain the above copyright notice, this
---    list of conditions and the following disclaimer.
--- 2. Redistributions in binary form must reproduce the above copyright notice,
---    this list of conditions and the following disclaimer in the documentation
---    and/or other materials provided with the distribution.
--- 3. Neither the name(s) of the above-listed copyright holder(s) nor the names
---    of its contributors may be used to endorse or promote products derived
---    from this software without specific prior written permission.
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
 --
--- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
--- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
--- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
--- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
--- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
--- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
--- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
--- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
--- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
 --
 -------------------------------------------------------------------------------
 --
@@ -61,9 +54,10 @@ use IEEE.STD_LOGIC_1164.ALL;
 entity SyncAsync is
    Generic (
       kResetTo : std_logic := '0'; --value when reset and upon init
-      kStages : natural := 2); --double sync by default
+      kStages : natural := 2; --double sync by default
+      kResetPolarity : std_logic := '1'); --aReset active-high by default
    Port (
-      aReset : in STD_LOGIC; -- active-high asynchronous reset
+      aReset : in STD_LOGIC; -- active-high/active-low asynchronous reset
       aIn : in STD_LOGIC;
       OutClk : in STD_LOGIC;
       oOut : out STD_LOGIC);
@@ -77,7 +71,7 @@ begin
 
 Sync: process (OutClk, aReset)
 begin
-   if (aReset = '1') then
+   if (aReset = kResetPolarity) then
       oSyncStages <= (others => kResetTo);
    elsif Rising_Edge(OutClk) then
       oSyncStages <= oSyncStages(oSyncStages'high-1 downto 0) & aIn;

--- a/ip/usb2device_v1_0/src/SyncAsync.vhd
+++ b/ip/usb2device_v1_0/src/SyncAsync.vhd
@@ -3,37 +3,30 @@
 -- File: SyncAsync.vhd
 -- Author: Elod Gyorgy
 -- Original Project: HDMI input on 7-series Xilinx FPGA
--- Date: 20 October 2014
+-- Date: 15 December 2017
 --
 -------------------------------------------------------------------------------
--- (c) 2014 Copyright Digilent Incorporated
--- All Rights Reserved
--- 
--- This program is free software; distributed under the terms of BSD 3-clause 
--- license ("Revised BSD License", "New BSD License", or "Modified BSD License")
+--MIT License
 --
--- Redistribution and use in source and binary forms, with or without modification,
--- are permitted provided that the following conditions are met:
+--Copyright (c) 2016 Digilent
 --
--- 1. Redistributions of source code must retain the above copyright notice, this
---    list of conditions and the following disclaimer.
--- 2. Redistributions in binary form must reproduce the above copyright notice,
---    this list of conditions and the following disclaimer in the documentation
---    and/or other materials provided with the distribution.
--- 3. Neither the name(s) of the above-listed copyright holder(s) nor the names
---    of its contributors may be used to endorse or promote products derived
---    from this software without specific prior written permission.
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
 --
--- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
--- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
--- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
--- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
--- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
--- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
--- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
--- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
--- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
 --
 -------------------------------------------------------------------------------
 --
@@ -61,9 +54,10 @@ use IEEE.STD_LOGIC_1164.ALL;
 entity SyncAsync is
    Generic (
       kResetTo : std_logic := '0'; --value when reset and upon init
-      kStages : natural := 2); --double sync by default
+      kStages : natural := 2; --double sync by default
+      kResetPolarity : std_logic := '1'); --aReset active-high by default
    Port (
-      aReset : in STD_LOGIC; -- active-high asynchronous reset
+      aReset : in STD_LOGIC; -- active-high/active-low asynchronous reset
       aIn : in STD_LOGIC;
       OutClk : in STD_LOGIC;
       oOut : out STD_LOGIC);
@@ -77,7 +71,7 @@ begin
 
 Sync: process (OutClk, aReset)
 begin
-   if (aReset = '1') then
+   if (aReset = kResetPolarity) then
       oSyncStages <= (others => kResetTo);
    elsif Rising_Edge(OutClk) then
       oSyncStages <= oSyncStages(oSyncStages'high-1 downto 0) & aIn;


### PR DESCRIPTION
While mixing some IP i found that the the SyncAsync block was present in multiple projects but newer ones had an extra generic.  This was causing issues in blocks that we using the new format and picking up the old code. Old code picking up the new format should default to the correct use.

This is only the for SynAsync blocks that have aReset, there is another block with aoReset that also has the same name.  That is a different fix.